### PR TITLE
Add better fan speed control switches and improve read and writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,53 @@
 version = 4
 
 [[package]]
+name = "bitflags"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,10 +60,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "libc"
@@ -25,11 +84,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "nvfans"
 version = "0.1.0"
 dependencies = [
  "glob",
+ "nvml-wrapper",
  "signal-hook",
+]
+
+[[package]]
+name = "nvml-wrapper"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d5c6c0ef9702176a570f06ad94f3198bc29c524c8b498f1b9346e1b1bdcbb3a"
+dependencies = [
+ "bitflags",
+ "libloading",
+ "nvml-wrapper-sys",
+ "static_assertions",
+ "thiserror",
+ "wrapcenum-derive",
+]
+
+[[package]]
+name = "nvml-wrapper-sys"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd23dbe2eb8d8335d2bce0299e0a07d6a63c089243d626ca75b770a962ff49e6"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9695f8df41bb4f3d222c95a67532365f569318332d03d5f3f67f37b20e6ebdf0"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+dependencies = [
+ "proc-macro2",
 ]
 
 [[package]]
@@ -53,6 +164,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "2.0.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,4 +225,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "wrapcenum-derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76ff259533532054cfbaefb115c613203c73707017459206380f03b3b3f266e"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,5 @@ edition = "2024"
 
 [dependencies]
 glob = "0.3.3"
+nvml-wrapper = "0.11.0"
 signal-hook = "0.4.1"

--- a/src/fan_control.rs
+++ b/src/fan_control.rs
@@ -1,7 +1,7 @@
 use crate::suspend_detector::SuspendDetector;
 use glob::glob;
 use std::fs::read_to_string;
-use std::io::Write;
+use std::io::{BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::process::exit;
 use std::time::Instant;
@@ -273,9 +273,14 @@ impl FanControl {
             return TEMP_INVALID;
         }
 
-        let _ = f.unwrap().read_to_string(&mut buf);
+        let mut reader = BufReader::new(f.unwrap());
 
-        // println!("Path: {}", filename.display());
+        let result = reader.read_to_string(&mut buf);
+
+        if result.is_err() {
+            return TEMP_INVALID;
+        }
+
         if !buf.is_empty() {
             let i = buf.trim_end_matches('\n').parse::<i64>();
             match i {
@@ -370,15 +375,16 @@ impl FanControl {
     pub fn write_to_fan(&mut self, command: &str, value: &str) -> std::io::Result<()> {
         let exists = Path::new(FAN_CONTROL_FILE).exists();
         if exists {
-            let f = File::options()
+            let mut f = File::options()
                 .write(true)
                 .read(true)
                 .truncate(false)
                 .create(false)
                 .open(FAN_CONTROL_FILE);
             if f.is_ok() {
+                let mut writer = BufWriter::new(f.as_mut().unwrap());
                 let string_to_write = format!("{} {}", command, value);
-                let bytes_written = f.unwrap().write(string_to_write.as_bytes());
+                let bytes_written = writer.write(string_to_write.as_bytes());
                 if bytes_written.is_err() {
                     self.exit_if_first_tick();
                     self.reset();

--- a/src/fan_control.rs
+++ b/src/fan_control.rs
@@ -11,6 +11,7 @@ const TEMP_FILES_GLOB: &str = "/sys/class/hwmon/hwmon*/temp*_input"; // Gets the
 const FAN_CONTROL_FILE: &str = "/proc/acpi/ibm/fan"; // controls the fan speed
 const TEMP_INVALID: i64 = i64::min_value();
 const CONFIG_FILE: &str = "/etc/nvfans.conf";
+const TICK_HYSTERESIS: i64 = 2;
 
 pub const DEFAULT_WATCHDOG_SECS: i64 = 120;
 pub const WATCHDOG_GRACE_PERIOD_SECS: i64 = 2;
@@ -202,6 +203,7 @@ pub struct FanControl {
     last_watchdog_ping: Instant,
     pending_sleep: bool,
     pending_resume: bool,
+    tick_penalty: i64,
 }
 
 impl FanControl {
@@ -220,6 +222,7 @@ impl FanControl {
             last_watchdog_ping: Instant::now(),
             pending_sleep: false,
             pending_resume: false,
+            tick_penalty: 3,
         }
     }
 
@@ -314,6 +317,7 @@ impl FanControl {
 
     pub fn set_fan_level(&mut self) -> SetFanStatus {
         let max_temp = self.get_max_temp();
+        let mut temp_penalty = 0;
 
         if max_temp == TEMP_INVALID {
             let status = self.write_to_fan("level", "full-speed");
@@ -323,12 +327,23 @@ impl FanControl {
             return SetFanStatus::FanLevelInvalid;
         }
 
+        if self.tick_penalty > 0 {
+            self.tick_penalty -= 1;
+        }
+
         for rule in self.temperature_configs.clone() {
-            if rule.high >= max_temp && rule.low <= max_temp {
+            if rule == self.current_rule {
+                if self.tick_penalty == 0 {
+                    return SetFanStatus::FanLevelNotSet;
+                }
+                temp_penalty = TICK_HYSTERESIS;
+            }
+            if rule.high - temp_penalty >= max_temp && rule.low <= max_temp {
                 if self.current_rule != rule {
                     self.current_rule = rule.clone();
                     let value = convert_fan_speed(rule.speed);
                     let status = self.write_to_fan("level", &value);
+                    self.tick_penalty = TICK_HYSTERESIS;
                     if status.is_err() {
                         return SetFanStatus::FanLevelError;
                     }

--- a/src/fan_control.rs
+++ b/src/fan_control.rs
@@ -11,7 +11,7 @@ const TEMP_FILES_GLOB: &str = "/sys/class/hwmon/hwmon*/temp*_input"; // Gets the
 const FAN_CONTROL_FILE: &str = "/proc/acpi/ibm/fan"; // controls the fan speed
 const TEMP_INVALID: i64 = i64::min_value();
 const CONFIG_FILE: &str = "/etc/nvfans.conf";
-const TICK_HYSTERESIS: i64 = 2;
+const TICK_HYSTERESIS: i64 = 4;
 
 pub const DEFAULT_WATCHDOG_SECS: i64 = 120;
 pub const WATCHDOG_GRACE_PERIOD_SECS: i64 = 2;
@@ -333,7 +333,7 @@ impl FanControl {
 
         for rule in self.temperature_configs.clone() {
             if rule == self.current_rule {
-                if self.tick_penalty == 0 {
+                if self.tick_penalty > 0 {
                     return SetFanStatus::FanLevelNotSet;
                 }
                 temp_penalty = TICK_HYSTERESIS;


### PR DESCRIPTION
Have a tick countdown before switching fan speeds to remove any possible frequent fan speed switches. 

For frequent reads and writes, BufReader and BufWriter is more efficient. 